### PR TITLE
updates for firecrown v1.11

### DIFF
--- a/forecast_3x2pt.py
+++ b/forecast_3x2pt.py
@@ -9,10 +9,10 @@ import sacc
 import pyccl as ccl
 import pyccl.nl_pt
 
-import firecrown.likelihood.gauss_family.statistic.source.weak_lensing as wl
-import firecrown.likelihood.gauss_family.statistic.source.number_counts as nc
-from firecrown.likelihood.gauss_family.statistic.two_point import TwoPoint
-from firecrown.likelihood.gauss_family.gaussian import ConstGaussian
+import firecrown.likelihood.weak_lensing as wl
+import firecrown.likelihood.number_counts as nc
+from firecrown.likelihood.two_point import TwoPoint
+from firecrown.likelihood.gaussian import ConstGaussian
 from firecrown.parameters import ParamsMap
 from firecrown.modeling_tools import ModelingTools
 from firecrown.likelihood.likelihood import Likelihood

--- a/jobscript_perlmutter.sh
+++ b/jobscript_perlmutter.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -l
 #SBATCH --qos=regular
-#SBATCH --constraint=haswell
 #SBATCH -J desc-tutorial
 #SBATCH -n 100
 #SBATCH --cpus-per-task=1
@@ -13,7 +12,7 @@
 cd $SCRATCH/desc/minimal_mcmc
 
 # Load environment
-source /global/cfs/cdirs/lsst/groups/MCP/setup_forecasts_int.sh
+source /global/cfs/cdirs/lsst/groups/MCP/setup-cosmology-dev.sh
 
 # Run the chain
 time srun cosmosis --mpi forecast_3x2pt.ini


### PR DESCRIPTION
Updates for Firecrown v1.11
I'll note that while I can run this on Perlmutter just fine, the job is timing out after 6 hours (I doubled the default time of 3 hours in the job script). I'm not sure if this is expected or if there is a way to reduce this job a little bit to make it run in a shorter amount of time.